### PR TITLE
Set command to run after start Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,3 @@
 {
-  "onCreateCommand": ["make", "up"]
+  "postCreateCommand": ["make", "up"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "onCreateCommand": ["make", "up"]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,3 @@
 {
-  "postCreateCommand": ["make", "up"]
+  "postStartCommand": ["make", "up"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
 {
-  "postStartCommand": ["make", "up"],
   "postAttachCommand": ["make", "up"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
 {
-  "postStartCommand": ["make", "up"]
+  "postStartCommand": ["make", "up"],
+  "postAttachCommand": ["make", "up"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,3 @@
 {
-  "postAttachCommand": ["make", "up"]
+  "postAttachCommand": ["make", "restart"]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VOLUME_NAME = $(shell docker volume ls | grep getting-started-with-analytics-engineering | awk '{print $$2}')
 
 up:
-	docker-compose up -d --force
+	docker-compose up -d
 
 down:
 	docker-compose down
@@ -12,3 +12,5 @@ remove_volume:
 clean: down remove_volume
 
 reset: down remove_volume up
+
+restart: down up

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VOLUME_NAME = $(shell docker volume ls | grep getting-started-with-analytics-engineering | awk '{print $$2}')
 
 up:
-	docker-compose up -d --always-recreate-deps
+	docker-compose up -d --build
 
 down:
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VOLUME_NAME = $(shell docker volume ls | grep getting-started-with-analytics-engineering | awk '{print $$2}')
 
 up:
-	docker-compose up -d --build
+	docker-compose up -d --force
 
 down:
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VOLUME_NAME = $(shell docker volume ls | grep getting-started-with-analytics-engineering | awk '{print $$2}')
 
 up:
-	docker-compose up -d
+	docker-compose up -d --always-recreate-deps
 
 down:
 	docker-compose down


### PR DESCRIPTION
## What's new?

- Added the `postAttachCommand` to run a custom command after starting a Codespaces instance.
- Added the `make restart` short command for running Docker Compose to recreate containers.

## Next actions

1. Set up [prebuild](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds) for this repository.